### PR TITLE
Bug fixes

### DIFF
--- a/lofar_query.py
+++ b/lofar_query.py
@@ -9,27 +9,44 @@ data = pd.read_csv('paper_data.csv')
 
 dois = [j for j in data['DOI']]
 
-ids = [list(ads.SearchQuery(doi=j))[0].identifier for j in dois]
+ads_data = [list(ads.SearchQuery(doi=j, fl=['title', 'pubdate', 'identifier']))[0] for j in dois]
+
+unpacked_data = []
+for i in ads_data:
+    unpacked_data.append([i.title, i.pubdate, i.identifier])
+
+unpacked_data = np.array(unpacked_data)
+unpacked_titles = unpacked_data[:,0]
+unpacked_pubdates = unpacked_data[:,1]
+unpacked_identifiers = unpacked_data[:,2]
+
 
 arxiv_list = []
-for i in range(0,len(ids)):
-    for k in ids[i]:
+for i in range(0,len(unpacked_identifiers)):
+    for k in unpacked_identifiers[i]:
         if k[:5] == 'arXiv':
             arxiv_list.append([k[6:], i])
 
 arxiv_list = np.array(arxiv_list)
 
-papers = arxiv.query(id_list=arxiv_list[:,0], max_results=len(ids))
+#final titles and pubdates
+paper_titles = []
+paper_pubdates = []
+for i in arxiv_list[:,1]:
+    paper_titles.append(unpacked_titles[i.astype(np.int)])
+    paper_pubdates.append(unpacked_pubdates[i.astype(np.int)])
+
+arxiv_papers = arxiv.query(id_list=arxiv_list[:,0], max_results=len(unpacked_identifiers))
 
 def temp_file(obj):
     return 'temp'
 
 codes = []
-for i in tqdm(papers):
-    arxiv.download(i, slugify=temp_file)
-    paper = list(ads.SearchQuery(title=i.title))[0] 
+for i in tqdm(range(len(arxiv_papers))):
+    arxiv.download(arxiv_papers[i], slugify=temp_file)
+    # paper = list(ads.SearchQuery(title=i.title))[0] 
     hits = os.popen('pdfgrep -o "LT[0-9].{0,5}|LC[0-9].{0,5}|L[0-9][0-9][0-9][0-9][0-9]{0,2}|DDT[0-9]{0,5}" temp.pdf').read()
-    codes.append(np.array([paper.title,paper.pubdate,hits.splitlines()]))
+    codes.append(np.array([paper_titles[i],paper_pubdates[i],hits.splitlines()]))
     os.system('rm temp.pdf')
 
 codes = np.array(codes)


### PR DESCRIPTION
Instead of requiring (3*N+1) queries to ADS (N being number of papers), now requires only N queries. 
Fixed the problems due to differences between the paper titles from retrieved ADS and arXiv. 